### PR TITLE
Simplify `broadcasts` request flow

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+aiohttp==3.8.1
+dateparser==1.1.1
+numpy==1.22.4
+pandas==1.4.2
+pytz==2022.1
+requests==2.27.1
+SQLAlchemy==1.4.37
+xmltodict==0.13.0


### PR DESCRIPTION
The `broadcasts` endpoint seems unable to handle larger requests and consistently returns 504 errors when the request is sent with a max limit of 1,000 records. However since the ACLU has a relatively low volume of broadcasts (there are only 311 all time as of today), we can reduce the risk of error by breaking up our request into smaller chunks. This PR essentially re-routes requests to the `broadcasts` endpoint to a loop that requests and concatenates 20 records at a time, rather than send simultaneous requests for 1,000 records at a time with an `asyncio` loop.

This PR also resolves an unclosed loop in another part of the script. 